### PR TITLE
Fix id token for openid connect password stratedy

### DIFF
--- a/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
@@ -12,9 +12,9 @@ module Doorkeeper
         private
 
         def after_successful_response
-          super
           id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
           @response.id_token = id_token
+          super
         end
       end
     end


### PR DESCRIPTION
Return super in after_successful_response hook so the id_token is available in the Doorkeeper hook after_successful_strategy_response